### PR TITLE
add logic to consider both speaker 1 and 2 when generating next speaker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ignore/
+agenda.yaml

--- a/tmag/cmd/generateSchedule.go
+++ b/tmag/cmd/generateSchedule.go
@@ -83,11 +83,16 @@ func generateUniqueAgenda(roles []string, members []string, schedule []internal.
 	for _, role := range roles {
 		previousAssignments[role] = make([]string, maxNumberAgendasToCompare+1)
 		for i := 0; i < maxNumberAgendasToCompare && i < len(schedule); i++ {
-			previousMember, err := schedule[i].GetMemberForRole(role)
-			if err != nil {
-				return newAgenda, err
+			if internal.IsSpeakerRole(role) {
+				previousSpeakers := schedule[i].GetSpeakers()
+				previousAssignments[role] = append(previousAssignments[role], previousSpeakers...)
+			} else {
+				previousMember, err := schedule[i].GetMemberForRole(role)
+				if err != nil {
+					return newAgenda, err
+				}
+				previousAssignments[role] = append(previousAssignments[role], previousMember)
 			}
-			previousAssignments[role] = append(previousAssignments[role], previousMember)
 		}
 	}
 

--- a/tmag/internal/agenda.go
+++ b/tmag/internal/agenda.go
@@ -37,6 +37,22 @@ func NewAgenda() Agenda {
 	return Agenda{}
 }
 
+func IsSpeakerRole(role string) bool {
+	return strings.Contains(role, "speaker")
+}
+
+func (a *Agenda) GetSpeakers() []string {
+	speakers := []string{}
+	if a.Speaker1 != "" {
+		speakers = append(speakers, a.Speaker1)
+	}
+	if a.Speaker2 != "" {
+		speakers = append(speakers, a.Speaker2)
+	}
+
+	return speakers
+}
+
 func (a *Agenda) GetMemberForRole(role string) (string, error) {
 	roleLower := strings.ReplaceAll(strings.ToLower(role), " ", "")
 	var member string


### PR DESCRIPTION
# What
Add logic to consider both speaker 1 and 2 when generating the next speaker.

# Why
Reduce chance of scheduling the same speaker two meetings in a row.